### PR TITLE
API function and endpoint to get words by userId, its mock data

### DIFF
--- a/mocks/words/getLoggedUserWords.json
+++ b/mocks/words/getLoggedUserWords.json
@@ -1,0 +1,7 @@
+{
+    "requestContext": {
+       "identity": {
+          "cognitoIdentityId": "TEST-LOCAL-USER-A"
+       }
+    }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,6 +59,14 @@ functions:
           method: post
           cors: true
           authorizer: aws_iam
+  getLoggedUserWords:
+    handler: src/modules/words/getByUser.main
+    events:
+      - http:
+          path: words
+          method: get
+          cors: true
+          authorizer: aws_iam
   hello:
     handler: handler.hello
     events:

--- a/src/modules/words/getByUser.ts
+++ b/src/modules/words/getByUser.ts
@@ -1,0 +1,31 @@
+import { APP_CONSTANTS } from '../../config/app_constants';
+import * as AWS from "aws-sdk";
+import getResponse from '../../utils/responseUtils';
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient({
+    'region': 'us-east-1'
+});
+
+export async function main(event, context, callback) {
+            
+    const params = {
+        TableName: APP_CONSTANTS.WORDS_TABLE,
+        KeyConditionExpression: "userId = :userId",
+        ExpressionAttributeValues: {
+            ":userId": event.requestContext.identity.cognitoIdentityId
+        }
+    };
+    try {
+        const data = await dynamoDb.query(params).promise();
+        
+        if (data.Items) {
+            const response = getResponse(200, data.Items);
+            callback(null, response);
+        } else {
+            throw new Error('Items not found');
+        }
+    } catch (error) {
+        const errResponse = getResponse(500, error);
+        callback(errResponse, null);
+    }
+}

--- a/src/utils/responseUtils.ts
+++ b/src/utils/responseUtils.ts
@@ -1,0 +1,13 @@
+
+const getResponse = (statusCode, body) => {
+    return {
+        statusCode: statusCode,
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Credentials": true
+        },
+        body: JSON.stringify(body)
+    };
+}
+
+export default getResponse;


### PR DESCRIPTION
## Story or Defect Link

n/a

## Description

added API function to get words by userId, added endpoint in serverless.yml to map to this function. Also its mock test data

## Screenshots

![9](https://user-images.githubusercontent.com/13605214/50381219-0eaa5780-0647-11e9-85f3-1fd1675b5454.png)


## Checklist:

- [x] Console Logs removed
- [x] style guidelines followed
- [x] appropriate code comments have been added

## PR Reviews

- [x] Dev LGTM
